### PR TITLE
DIRECTORY-4629: escape request URL

### DIFF
--- a/lib/bamboozled/api/base.rb
+++ b/lib/bamboozled/api/base.rb
@@ -29,7 +29,7 @@ module Bamboozled
             }.update(options[:headers] || {})
           }
 
-          response = HTTParty.send(method, "#{path_prefix}#{path}", httparty_options)
+          response = HTTParty.send(method, URI.escape("#{path_prefix}#{path}"), httparty_options)
           params[:response] = response.inspect.to_s
 
           case response.code


### PR DESCRIPTION
## Status
READY

## Description
Escape request URL before sending. Request URL may contain symbols like '#' and etc. Those unescaped symbols could break the request and not all fields from bamboo would be returned.

#### Jira
https://onelogin2.atlassian.net/browse/DIRECTORY-4629
