### PR TITLE
ENT-631: Remove use of unencrypted protos from gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 gemspec
 
 group :test do


### PR DESCRIPTION
## Status
**READY**

## Description
This changes network protocol for fetching metadata from rubygems to use an encrypted protocol.

## Steps to Test or Reproduce
Install the gem dependencies and verify that the metadata is pulled from rubygems via https. Before we would see

```
$ bundle install
Fetching https://github.com/foxwill/gmail.git
Fetching gem metadata from http://rubygems.org/...........
```

but with this change we see

```
$ bundle install
Fetching https://github.com/foxwill/gmail.git
Fetching gem metadata from https://rubygems.org/...........
```

## Impacted Areas in Application
Gemfile dependencies

## References
Add any reference material:

#### Jira
- https://onelogin2.atlassian.net/browse/ENT-631

