### PR TITLE
DIRECTORY-5406: BambooHR User Sync Issue

### DIFF
--- a/lib/bamboozled/api/base.rb
+++ b/lib/bamboozled/api/base.rb
@@ -60,7 +60,7 @@ module Bamboozled
           when 502
             raise Bamboozled::GatewayError.new(response, params, 'The load balancer or web server had trouble connecting to the Bamboo app. Please try the request again.')
           when 503
-            raise Bamboozled::ServiceUnavailable.new(response, params, 'The bamboo service is refusing requests. Please try again later.')
+            raise Bamboozled::ServiceUnavailable.new(response, params, 'The BambooHR directory is refusing this request due to rate limiting. Please try again later.')
           else
             raise Bamboozled::InformBamboo.new(response, params, 'An error occurred that we do not now how to handle. Please contact BambooHR.')
           end

--- a/lib/bamboozled/api/base.rb
+++ b/lib/bamboozled/api/base.rb
@@ -60,7 +60,7 @@ module Bamboozled
           when 502
             raise Bamboozled::GatewayError.new(response, params, 'The load balancer or web server had trouble connecting to the Bamboo app. Please try the request again.')
           when 503
-            raise Bamboozled::ServiceUnavailable.new(response, params, 'The service is temporarily unavailable. Please try the request again.')
+            raise Bamboozled::ServiceUnavailable.new(response, params, 'The bamboo service is refusing requests. Please try again later.')
           else
             raise Bamboozled::InformBamboo.new(response, params, 'An error occurred that we do not now how to handle. Please contact BambooHR.')
           end


### PR DESCRIPTION
## Status
READY

## Description
We need to better surface the error and make it clear to our customers that this is Bamboo throttling us. Something like the original Bamboozled::ServiceUnavailable : 503 - plus The bamboo service is refusing requests. Please try again later.

## Related PRs
branch | PR
------ | ------
DIRECTORY-5496 | [directory-service](https://github.com/onelogin/directory-service/pull/250)

#### Jira
https://onelogin2.atlassian.net/browse/DIRECTORY-5406
